### PR TITLE
fix className + fix react dependency version

### DIFF
--- a/src/component/index.css
+++ b/src/component/index.css
@@ -118,3 +118,11 @@
 	line-height: 15px;
 	cursor: pointer;
 }
+
+.flipMove {
+	display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    width: 100%;
+}

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -162,7 +162,7 @@ class ReactImageUploadComponent extends React.PureComponent {
 
 	render() {
 		return (
-			<div className="fileUploader" style={this.props.style}>
+			<div className={"fileUploader " + this.props.className} style={this.props.style}>
 				<div className="fileContainer">
 					{this.renderIcon()}
 					{this.renderLabel()}
@@ -183,7 +183,6 @@ class ReactImageUploadComponent extends React.PureComponent {
 						multiple="multiple"
 						onChange={this.onDropFile}
 						accept={this.props.accept}
-						className={this.props.className}
 					/>
 					{ this.props.withPreview ? this.renderPreview() : null }
 				</div>

--- a/src/component/package.json
+++ b/src/component/package.json
@@ -7,7 +7,7 @@
 	  "url": "git://github.com/jakehartnell/react-image-upload.git"
   },
   "dependencies": {
-	  "react": "^16.20.0",
+	  "react": "^16.2.0",
 	  "react-flip-move": "^3.0.1"
   },
   "scripts": {


### PR DESCRIPTION
I have moved _this.props.className_ upper in the main component's div to allow better formatting of the div of any of the inner elements (for example to add/overwrite styles with css-in-js utilities like "styled-components").
React version has also been fixed from 16.20 to 16.2 which is the correct one.