### PR TITLE
Importing UploadIcon.svg as Component

### DIFF
--- a/src/component/index.css
+++ b/src/component/index.css
@@ -74,9 +74,6 @@
 .fileContainer .uploadIcon {
 	width: 50px;
 	height: 50px;
-	background: url(UploadIcon.svg);
-	-webkit-background-size: cover;
-	background-size: cover;
 }
 
 .fileContainer .uploadPicturesWrapper {

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import './index.css';
 import FlipMove from 'react-flip-move';
+import UploadIcon from './UploadIcon.svg';
 
 const styles = {
 	display: "flex",
@@ -82,7 +83,8 @@ class ReactImageUploadComponent extends React.PureComponent {
 	 */
 	renderIcon() {
 		if (this.props.withIcon) {
-			return <div className="uploadIcon"/>;
+			return <img src={UploadIcon} className="uploadIcon" 
+				alt="Upload Icon" />;
 		}
 	}
 


### PR DESCRIPTION
This keeps the original SVG file rather than inlining it as in #22.
The image is passed instead as a the `src` property to the `<img />` tag. 
This fixes #21.