### PR TITLE
defaultImage initialization

### DIFF
--- a/src/component/compiled.js
+++ b/src/component/compiled.js
@@ -49,7 +49,7 @@ var ReactImageUploadComponent = function (_React$Component) {
     var _this = _possibleConstructorReturn(this, (ReactImageUploadComponent.__proto__ || Object.getPrototypeOf(ReactImageUploadComponent)).call(this, props));
 
     _this.state = {
-      pictures: [],
+      pictures: props.defaultImage ? [props.defaultImage] : [],
       files: [],
       notAcceptedFileType: [],
       notAcceptedFileSize: []
@@ -75,9 +75,9 @@ var ReactImageUploadComponent = function (_React$Component) {
 
   }, {
     key: 'componentWillReceiveProps',
-    value: function componentWillReceiveProps() {
-      if (this.props.defaultImage) {
-        this.setState({ pictures: [this.props.defaultImage] });
+    value: function componentWillReceiveProps(nextProps) {
+      if (nextProps.defaultImage) {
+        this.setState({ pictures: [nextProps.defaultImage] });
       }
     }
 

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -16,7 +16,7 @@ class ReactImageUploadComponent extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      pictures: [],
+      pictures: props.defaultImage ? [props.defaultImage] : [],
       files: [],
       notAcceptedFileType: [],
       notAcceptedFileSize: []
@@ -36,9 +36,9 @@ class ReactImageUploadComponent extends React.Component {
   /*
    Load image at the beggining if defaultImage prop exists
    */
-  componentWillReceiveProps(){
-    if(this.props.defaultImage){
-      this.setState({pictures: [this.props.defaultImage]});
+  componentWillReceiveProps(nextProps){
+    if(nextProps.defaultImage){
+      this.setState({pictures: [nextProps.defaultImage]});
     }
   }
 


### PR DESCRIPTION
Correction for #58 
In order to not have to update props two times to update defaultImage, we need to handle nextProps, and not actual this.props (old values).