### PR TITLE
Fix for issue#66

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ class App extends React.Component {
 
     onDrop(pictureFiles, pictureDataURLs) {
         this.setState({
-            pictures: this.state.pictures.concat(pictureFiles),
+            pictures: pictureFiles
         });
     }
 


### PR DESCRIPTION
Issue#66: onchange being fired twice, remove image does not remove item from state.

Reason and Fix:
The issue is related to call of 'onDrop' function and updating the state. While
updating, the state is getting mutated which is creating the multiple entries of
images even after being deleted. Hence,  instead of mutating state returning
a new state solves the issue.