### PR TITLE
remove duplicate declaration for defaultImage

### DIFF
--- a/src/component/index.d.ts
+++ b/src/component/index.d.ts
@@ -22,7 +22,6 @@ interface Props {
   errorClass?: string
   errorStyle?: object
   singleImage?: boolean
-  defaultImage?: string
   style?: object
   defaultImage?: string
 }


### PR DESCRIPTION
When using in a project with typescript the compile throws "Type error: Duplicate identifier 'defaultImage'.  TS2300", this should fix it.
