### PR TITLE
Clear uploaded files

### DIFF
--- a/src/component/index.js
+++ b/src/component/index.js
@@ -204,7 +204,7 @@ class ReactImageUploadComponent extends React.Component {
   }
 
   clearPictures() {
-    this.setState({pictures: []})
+    this.setState({pictures: [], files:[]})
   }
 
   render() {


### PR DESCRIPTION
- The files that are in the handler are not cleared when an upload happens. This sets a clean slate for the next upload