### PR TITLE
fixed typescript error about arg of onChange

### DIFF
--- a/src/component/index.d.ts
+++ b/src/component/index.d.ts
@@ -3,7 +3,7 @@ import { Component } from 'react'
 interface Props {
   className?: string
   fileContainerStyle?: object
-  onChange?: (files: File[]) => void
+  onChange?: (files: File[],pictures:string[]) => void
   buttonClassName?: string
   buttonStyles?: object
   withPreview?: boolean


### PR DESCRIPTION
Hi there.
Thanks for nice modules!!

I use this module for making image uploader, and I wanted to get image converted to base64 from onChange.
I checked the code, and I found that ImageUploader's props.onChange can got two args files and pictures and pictures show base64 code, but in index.d.ts props.onChange is set to get only one arg so ts compiler returns error.

I fixed this TypeError.