### PR TITLE
Early return in componentWillReceiveProps if singleImage is true

### DIFF
--- a/src/component/index.js
+++ b/src/component/index.js
@@ -41,6 +41,9 @@ class ReactImageUploadComponent extends React.Component {
    Load image at the beggining if defaultImage prop exists
    */
   componentWillReceiveProps(nextProps){
+    if(this.props.singleImage){
+      return;
+    }
     if(nextProps.defaultImages !== this.props.defaultImages){
       this.setState({pictures: nextProps.defaultImages});
     }


### PR DESCRIPTION
The case: let say we are editing a post content. We want to show a default image from a url received from database, and we want to change image preview if user choose an image (change the image).

The current implementation, `componentWillreceiveProps` will always invoked when `onChange` is fired because `defaultImages` is a primitive (array). This makes image preview won't change.

With `singleImage` props being `true`, we want to preview the selected image, not the default one, if user is going to change image.

Thank you