### PR TITLE
Add same image more than once to and then try to remove one of them

### DIFF
--- a/src/component/compiled.js
+++ b/src/component/compiled.js
@@ -172,12 +172,13 @@ var ReactImageUploadComponent = function (_React$Component) {
     value: function readFile(file) {
       return new Promise(function (resolve, reject) {
         var reader = new FileReader();
+        var timestamp = new Date().getTime();
 
         // Read the image via FileReader API and save image result in state.
         reader.onload = function (e) {
           // Add the file name to the data URL
           var dataURL = e.target.result;
-          dataURL = dataURL.replace(";base64", ';name=' + file.name + ';base64');
+          dataURL = dataURL.replace(";base64", ';name=' + file.name + ';timestamp=' + timestamp + ';base64');
           resolve({ file: file, dataURL: dataURL });
         };
 

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -118,12 +118,13 @@ class ReactImageUploadComponent extends React.Component {
   readFile(file) {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
+      let timestamp = new Date().getTime();
 
       // Read the image via FileReader API and save image result in state.
       reader.onload = function (e) {
         // Add the file name to the data URL
         let dataURL = e.target.result;
-        dataURL = dataURL.replace(";base64", `;name=${file.name};base64`);
+        dataURL = dataURL.replace(";base64", `;name=${file.name};timestamp=${timestamp};base64`);          
         resolve({file, dataURL});
       };
 


### PR DESCRIPTION
fix for this issue
https://github.com/JakeHartnell/react-images-upload/issues/171


added timestamp value for each image dataUrl value
if we upload same image twice 
then filenames are identical in those two images and dataUrl string have two different values
because timestamp parts are different
